### PR TITLE
fix(RadioGroup): handle 'touched' state when using with 'Tag' component

### DIFF
--- a/src/RadioGroup/index.test.tsx
+++ b/src/RadioGroup/index.test.tsx
@@ -2,6 +2,7 @@ import React, { createRef } from 'react';
 import userEvent from '@testing-library/user-event';
 import { RadioGroup as CoreComponentsRadioGroup } from '@alfalab/core-components/radio-group';
 import { Radio } from '@alfalab/core-components/radio';
+import { Tag } from '@alfalab/core-components/tag';
 import { FormikProps } from 'formik';
 import { renderWithFormik, render, screen } from 'test-utils';
 import { RadioGroup } from '.';
@@ -63,13 +64,34 @@ it('should update value inside formik context', async () => {
     expect(formikRef.current?.values.field).toBe('two');
 });
 
-it('should update `touched` state inside formik context', async () => {
+it('should update `touched` state inside formik context with `Radio`', async () => {
     const formikRef = createRef<FormikProps<Values>>();
 
     renderWithFormik<Values>(
         <RadioGroup name="field">
             <Radio label="One" value="one" data-testid="input-one" />
             <Radio label="Two" value="two" data-testid="input-two" />
+        </RadioGroup>,
+        { initialValues: { field: '' }, innerRef: formikRef },
+    );
+
+    await userEvent.click(screen.getByTestId('input-two'));
+    await userEvent.click(document.body);
+
+    expect(formikRef.current?.touched.field).toBe(true);
+});
+
+it('should update `touched` state inside formik context with `Tag`', async () => {
+    const formikRef = createRef<FormikProps<Values>>();
+
+    renderWithFormik<Values>(
+        <RadioGroup name="field">
+            <Tag value="one" data-testid="input-one">
+                One
+            </Tag>
+            <Tag value="two" data-testid="input-two">
+                Two
+            </Tag>
         </RadioGroup>,
         { initialValues: { field: '' }, innerRef: formikRef },
     );

--- a/src/RadioGroup/index.tsx
+++ b/src/RadioGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Children, cloneElement, isValidElement } from 'react';
+import React, { FC, Children, cloneElement, isValidElement, FocusEventHandler } from 'react';
 import { SetRequired } from 'type-fest';
 import { useField } from 'formik';
 import {
@@ -6,7 +6,6 @@ import {
     RadioGroupProps as CoreComponentsRadioGroupProps,
 } from '@alfalab/core-components/radio-group';
 import { useFieldOkState } from '../hooks/useFieldOkState';
-import { useFieldBlurState } from '../hooks/useFieldBlurState';
 
 export type RadioGroupProps = SetRequired<CoreComponentsRadioGroupProps, 'name'>;
 
@@ -14,7 +13,6 @@ export const RadioGroup: FC<RadioGroupProps> = (props) => {
     const { name, children, onChange, ...restProps } = props;
     const [field, , form] = useField(name);
     const { error } = useFieldOkState(props);
-    const blurState = useFieldBlurState(props);
 
     const handleChange: RadioGroupProps['onChange'] = (event, payload) => {
         form.setValue(payload?.value);
@@ -24,11 +22,15 @@ export const RadioGroup: FC<RadioGroupProps> = (props) => {
         }
     };
 
+    const handleBlur: FocusEventHandler = () => {
+        form.setTouched(true);
+    };
+
     return (
         <CoreComponentsRadioGroup {...restProps} {...field} error={error} onChange={handleChange}>
-            {/* Maybe pass `blurState` to `CoreComponentsRadioGroup` after issue will be resoled — https://github.com/core-ds/core-components/issues/186 */}
+            {/* Maybe pass `blur` event handler to `CoreComponentsRadioGroup` after issue will be resolved — https://github.com/core-ds/core-components/issues/186 */}
             {Children.map(children, (child) =>
-                isValidElement(child) ? cloneElement(child, blurState) : child,
+                isValidElement(child) ? cloneElement(child, { onBlur: handleBlur }) : child,
             )}
         </CoreComponentsRadioGroup>
     );


### PR DESCRIPTION
Handle `touched` state when using with `Tag` component.