### PR TITLE
Specify the maximum version of `@alfalab/core-components`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "typescript": "^4.7.4"
     },
     "peerDependencies": {
-        "@alfalab/core-components": ">=20.0.0",
+        "@alfalab/core-components": ">=20.0.0 <=41.x.x",
         "formik": "^2.0.0",
         "react": ">=16.8.0"
     },


### PR DESCRIPTION
Set the maximum major supported version of `@alfalab/core-components` as 41.