### PR TITLE
feat(AmountInput): add support for 'max' prop

### DIFF
--- a/src/AmountInput/index.test.tsx
+++ b/src/AmountInput/index.test.tsx
@@ -101,3 +101,15 @@ it('should render error from formik context if touched', () => {
 
     expect(screen.queryByText('Error text')).toBeInTheDocument();
 });
+
+it('should ignore entered value which is greater than `max` prop', async () => {
+    const formikRef = createRef<FormikProps<Values>>();
+
+    renderWithFormik<Values>(<AmountInput name="field" max={1000} data-testid="input" />, {
+        initialValues: { field: '' },
+        innerRef: formikRef,
+    });
+    await userEvent.type(screen.getByTestId('input'), '99', { delay: 100 });
+
+    expect(formikRef.current?.values.field).toBe(900);
+});

--- a/src/AmountInput/index.tsx
+++ b/src/AmountInput/index.tsx
@@ -17,7 +17,13 @@ export const AmountInput: FC<AmountInputProps> = (props) => {
     const blurState = useFieldBlurState(props);
 
     const handleChange: AmountInputProps['onChange'] = (event, payload) => {
-        form.setValue(payload.value);
+        const { value } = payload;
+
+        if (value !== null && value > Number(restProps.max)) {
+            return;
+        }
+
+        form.setValue(value);
 
         if (onChange) {
             onChange(event, payload);


### PR DESCRIPTION
Ignore entered value which is greater than provided `max` prop.